### PR TITLE
Added zoom on province selected in drop down on farm location selection screen

### DIFF
--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/SoilDataViewModel.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/SoilDataViewModel.cs
@@ -32,6 +32,7 @@ using System.Threading.Tasks;
 using H.Avalonia.Views.ResultViews;
 using H.Core.Services;
 using H.Core.Services.StorageService;
+using Microsoft.Extensions.Logging;
 using SoilResultsView = H.Avalonia.Views.ResultViews.SoilResultsView;
 
 namespace H.Avalonia.ViewModels
@@ -149,7 +150,8 @@ namespace H.Avalonia.ViewModels
             IDialogService dialogService, 
             ICountrySettings countrySettings,
             IStorageService storageService,
-            Storage storage) : base(regionManager, storageService)
+            Storage storage,
+            ILogger logger) : base(regionManager, storageService, logger)
         {
             if (countrySettings != null)
             {
@@ -489,7 +491,7 @@ namespace H.Avalonia.ViewModels
         {
             if (string.IsNullOrEmpty(Address))
             {
-                Trace.TraceInformation($@"Cannot find location as an empty address was entered.");
+                Logger.LogDebug($@"Cannot find location as an empty address was entered.");
                 NotificationManager?.Show(new Notification("Address field empty",
                     Core.Properties.Resources.MessageEmptyAddress,
                     type: NotificationType.Information,
@@ -506,7 +508,7 @@ namespace H.Avalonia.ViewModels
             }
             catch (ArgumentOutOfRangeException e)
             {
-                Trace.TraceInformation($@"{e.Message}. Exception thrown in {nameof(OnGetCoordinates)} by class {nameof(SoilDataViewModel)}");
+                Logger.LogError($@"{e.Message}. Exception thrown in {nameof(OnGetCoordinates)} by class {nameof(SoilDataViewModel)}");
                 NotificationManager?.Show(new Notification("Invalid Address",
                     Core.Properties.Resources.MessageIncorrectAddress,
                     type: NotificationType.Error,
@@ -523,7 +525,7 @@ namespace H.Avalonia.ViewModels
             var address = await _mapHelpers.GetAddressFromLocationAsync(Latitude, Longitude);
             if (string.IsNullOrEmpty(address))
             {
-                Trace.TraceInformation($@"Cannot find the coordinate. Please enter correct latitude and longitude values");
+                Logger.LogDebug($@"Cannot find the coordinate. Please enter correct latitude and longitude values");
                 NotificationManager?.Show(new Notification("Incorrect Coordinate",
                     Core.Properties.Resources.MessageInValidCoordinateEntered,
                     type: NotificationType.Information,
@@ -559,7 +561,7 @@ namespace H.Avalonia.ViewModels
             var address = await _mapHelpers.GetAddressFromLocationAsync(Latitude, Longitude);
             if (string.IsNullOrEmpty(address))
             {
-                Trace.TraceInformation($@"Incorrect coordinate location cannot find matching address.");
+                Logger.LogDebug($@"Incorrect coordinate location cannot find matching address.");
                 NotificationManager?.Show(new Notification("Cannot find address",
                     Core.Properties.Resources.MessageIncorrectLocationSelected,
                     type: NotificationType.Information,

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/ViewModelBase.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/ViewModelBase.cs
@@ -111,6 +111,18 @@ namespace H.Avalonia.ViewModels
             }
         }
 
+        protected ViewModelBase(IRegionManager regionManager, IStorageService storageService, ILogger logger) : this(regionManager, storageService)
+        {
+            if (logger != null)
+            {
+                this.Logger = logger;
+            }
+            else
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+        }
+
         protected ViewModelBase(IRegionManager regionManager,
             IEventAggregator eventAggregator,
             IStorageService storageService, ILogger logger) : this(regionManager, storageService)

--- a/H.GUI.Avalonia/H.Avalonia/Views/SoilDataView.axaml.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Views/SoilDataView.axaml.cs
@@ -43,6 +43,17 @@ namespace H.Avalonia.Views
         /// </summary>
         private RasterizingTileLayer? _polygonLayer;
 
+        private MPoint _coordinateBritishColumbia = new MPoint(-13928197, 7300000);
+        private MPoint _coordinateAlberta = new MPoint(-12731248, 7300000); //7033804
+        private MPoint _coordinateSaskatchewan = new MPoint(-11800000, 7300000);
+        private MPoint _coordinateManitoba = new MPoint(-10900000, 7300000);
+        private MPoint _coordinateOntario = new MPoint(-9510000, 6400000);
+        private MPoint _coordinateQuebec = new MPoint(-7900000, 6300000);
+        private MPoint _coordinateNewBrunswick = new MPoint(-7400000, 5850000);
+        private MPoint _coordinatePrinceEdwardIsland = new MPoint(-7020000, 5830000);
+        private MPoint _coordinateNovaScotia = new MPoint(-7030000, 5650000);
+        private MPoint _coordinateNewfoundland = new MPoint(-6220792, 6250000);
+
         #endregion
 
         #region Properties
@@ -121,6 +132,7 @@ namespace H.Avalonia.Views
                             {
                                 _polygonLayer = new RasterizingTileLayer(CreateLayer(_viewModel.SelectedProvince), minTiles: 400, maxTiles: 800, renderFormat: RenderFormat.WebP);
                                 SoilTabMap.Map.Layers.Add(_polygonLayer);
+                                setCoordinatesOnProvinceSelected(_viewModel.SelectedProvince);
                             }
                         }
                         else
@@ -132,6 +144,67 @@ namespace H.Avalonia.Views
                         }
                         break;
                     }
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="selectedProvince"></param>
+        private void setCoordinatesOnProvinceSelected(Province selectedProvince)
+        {
+            switch (selectedProvince)
+            {
+                case (Province.BritishColumbia):
+                {
+                    SoilTabMap.Map.Navigator.CenterOnAndZoomTo(_coordinateBritishColumbia, resolution: 3500);
+                    break;
+                }
+                case (Province.Alberta):
+                {
+                    SoilTabMap.Map.Navigator.CenterOnAndZoomTo(_coordinateAlberta, resolution: 3500);
+                    break;
+                }
+                case (Province.Saskatchewan):
+                {
+                    SoilTabMap.Map.Navigator.CenterOnAndZoomTo(_coordinateSaskatchewan, resolution: 3500);
+                    break;
+                }
+                case (Province.Manitoba):
+                {
+                    SoilTabMap.Map.Navigator.CenterOnAndZoomTo(_coordinateManitoba, resolution: 3500);
+                    break;
+                }
+                case (Province.Ontario):
+                {
+                    SoilTabMap.Map.Navigator.CenterOnAndZoomTo(_coordinateOntario, resolution: 3900);
+                    break;
+                }
+                case (Province.Quebec):
+                {
+                    SoilTabMap.Map.Navigator.CenterOnAndZoomTo(_coordinateQuebec, resolution: 3000);
+                    break;
+                }
+                case (Province.NewBrunswick):
+                {
+                    SoilTabMap.Map.Navigator.CenterOnAndZoomTo(_coordinateNewBrunswick, resolution: 1200);
+                    break;
+                }
+                case (Province.PrinceEdwardIsland):
+                {
+                    SoilTabMap.Map.Navigator.CenterOnAndZoomTo(_coordinatePrinceEdwardIsland, resolution: 600);
+                    break;
+                }
+                case (Province.NovaScotia):
+                {
+                    SoilTabMap.Map.Navigator.CenterOnAndZoomTo(_coordinateNovaScotia, resolution: 1100);
+                    break;
+                }
+                case (Province.Newfoundland):
+                {
+                    SoilTabMap.Map.Navigator.CenterOnAndZoomTo(_coordinateNewfoundland, resolution: 1400);
+                    break;
+                }
             }
         }
 

--- a/H.GUI.Avalonia/H.Avalonia/Views/SoilDataView.axaml.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Views/SoilDataView.axaml.cs
@@ -29,7 +29,9 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using H.Core.Providers.Soil;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.Logging;
 using Point = NetTopologySuite.Geometries.Point;
 
 namespace H.Avalonia.Views
@@ -57,6 +59,8 @@ namespace H.Avalonia.Views
         private MPoint _coordinateNovaScotia = new MPoint(-7030000, 5650000);
         private MPoint _coordinateNewfoundland = new MPoint(-6250000, 6250000);
 
+        private ILogger _logger;
+
         #endregion
 
         #region Properties
@@ -77,8 +81,9 @@ namespace H.Avalonia.Views
 
         #region Constructors
 
-        public SoilDataView()
+        public SoilDataView(ILogger logger)
         {
+            _logger = logger;
             InitializeComponent();
             InitializeMap();
         }
@@ -135,7 +140,7 @@ namespace H.Avalonia.Views
                             {
                                 _polygonLayer = new RasterizingTileLayer(CreateLayer(_viewModel.SelectedProvince), minTiles: 400, maxTiles: 800, renderFormat: RenderFormat.WebP);
                                 SoilTabMap.Map.Layers.Add(_polygonLayer);
-                                setCoordinatesOnProvinceSelected(_viewModel.SelectedProvince);
+                                SetCoordinatesOnProvinceSelected(_viewModel.SelectedProvince);
                             }
                         }
                         else
@@ -154,8 +159,9 @@ namespace H.Avalonia.Views
         /// Sets the map coordinates and zoom level based on the selected province.
         /// </summary>
         /// <param name="selectedProvince">The province to center map on</param>
-        private void setCoordinatesOnProvinceSelected(Province selectedProvince)
+        private void SetCoordinatesOnProvinceSelected(Province selectedProvince)
         {
+            _logger.LogDebug("New province " + selectedProvince + " selected in " + nameof(SoilDataView));
             switch (selectedProvince)
             {
                 case (Province.BritishColumbia):
@@ -218,6 +224,7 @@ namespace H.Avalonia.Views
         /// </summary>
         private void InitializeMap()
         {
+            _logger.LogDebug("Attempting to initialize map in " + nameof(SoilDataView));
             SoilTabMap.Map.Layers.Add(OpenStreetMap.CreateTileLayer());
             SoilTabMap.Map.Navigator.Limiter = new ViewportLimiterKeepWithinExtent();
             //SoilMap.Map.Navigator.OverridePanBounds = panBounds;
@@ -230,6 +237,7 @@ namespace H.Avalonia.Views
                 BackColor = Color.White,
                 Opacity = 1,
             });
+            _logger.LogDebug("Map initialized successfully in " + nameof(SoilData));
         }
 
         /// <summary>
@@ -266,6 +274,7 @@ namespace H.Avalonia.Views
         /// <param name="e"></param>
         private void SoilMap_OnPointerPressed(object? sender, PointerPressedEventArgs e)
         {
+            _logger.LogDebug("New location selected in " + nameof(SoilDataView));
             // Get the properties of the pointer event so that we can determine the type of click.
             var properties = e.GetCurrentPoint(this).Properties;
             if (!properties.IsRightButtonPressed) return;
@@ -312,6 +321,7 @@ namespace H.Avalonia.Views
         /// <returns></returns>
         private ILayer CreateLayer(Province province)
         {
+            _logger.LogDebug("Drawing " + province + " polygons on top of " + nameof(SoilDataView) + " map.");
             var polygons = _viewModel.WktPolygonMap[province];
             return new Layer("Polygons")
             {

--- a/H.GUI.Avalonia/H.Avalonia/Views/SoilDataView.axaml.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Views/SoilDataView.axaml.cs
@@ -148,9 +148,9 @@ namespace H.Avalonia.Views
         }
 
         /// <summary>
-        /// 
+        /// Sets the map coordinates and zoom level based on the selected province.
         /// </summary>
-        /// <param name="selectedProvince"></param>
+        /// <param name="selectedProvince">The province to center map on</param>
         private void setCoordinatesOnProvinceSelected(Province selectedProvince)
         {
             switch (selectedProvince)

--- a/H.GUI.Avalonia/H.Avalonia/Views/SoilDataView.axaml.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Views/SoilDataView.axaml.cs
@@ -47,7 +47,7 @@ namespace H.Avalonia.Views
         /// Central coordinate points for all provinces used for map navigation when a province is selected.
         /// </summary>
         private MPoint _coordinateBritishColumbia = new MPoint(-13928197, 7300000);
-        private MPoint _coordinateAlberta = new MPoint(-12731248, 7300000); //7033804
+        private MPoint _coordinateAlberta = new MPoint(-12731248, 7300000);
         private MPoint _coordinateSaskatchewan = new MPoint(-11800000, 7300000);
         private MPoint _coordinateManitoba = new MPoint(-10900000, 7300000);
         private MPoint _coordinateOntario = new MPoint(-9510000, 6400000);
@@ -55,7 +55,7 @@ namespace H.Avalonia.Views
         private MPoint _coordinateNewBrunswick = new MPoint(-7400000, 5850000);
         private MPoint _coordinatePrinceEdwardIsland = new MPoint(-7020000, 5830000);
         private MPoint _coordinateNovaScotia = new MPoint(-7030000, 5650000);
-        private MPoint _coordinateNewfoundland = new MPoint(-6220792, 6250000);
+        private MPoint _coordinateNewfoundland = new MPoint(-6250000, 6250000);
 
         #endregion
 

--- a/H.GUI.Avalonia/H.Avalonia/Views/SoilDataView.axaml.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Views/SoilDataView.axaml.cs
@@ -43,6 +43,9 @@ namespace H.Avalonia.Views
         /// </summary>
         private RasterizingTileLayer? _polygonLayer;
 
+        /// <summary>
+        /// Central coordinate points for all provinces used for map navigation when a province is selected.
+        /// </summary>
         private MPoint _coordinateBritishColumbia = new MPoint(-13928197, 7300000);
         private MPoint _coordinateAlberta = new MPoint(-12731248, 7300000); //7033804
         private MPoint _coordinateSaskatchewan = new MPoint(-11800000, 7300000);


### PR DESCRIPTION
Coordinates/zoom for each province was derived from running Holos in its default running window size (not fullscreen). Finding coordinate values that centered on the province or in the case of Quebec a point that centers on all polygons but doesn't show the top of the province and finding a suitable zoom (resolution) value to show all polygons/province borders.