### PR TITLE
Fix for setting active farm in options

### DIFF
--- a/H.GUI.Avalonia/H.Avalonia/Infrastructure/DependencyInjection/ContainerRegistrationService.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Infrastructure/DependencyInjection/ContainerRegistrationService.cs
@@ -195,7 +195,7 @@ namespace H.Avalonia.Infrastructure.DependencyInjection
             containerRegistry.RegisterForNavigation<CountrySelectionView, CountrySelectionViewModel>();
             containerRegistry.RegisterForNavigation<FarmOptionsView, FarmOptionsViewModel>();
             containerRegistry.RegisterForNavigation<FarmCreationView, FarmCreationViewModel>();
-            containerRegistry.RegisterForNavigation<FarmOpenExistingView, FarmOpenExistingViewmodel>();
+            containerRegistry.RegisterForNavigation<FarmOpenExistingView, FarmOpenExistingViewModel>();
             containerRegistry.RegisterForNavigation<StartView, StartViewModel>();
             
             _logger.LogDebug("Completed registration of core application views");

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/ComponentViews/MyComponentsViewModel.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/ComponentViews/MyComponentsViewModel.cs
@@ -24,7 +24,6 @@ public class MyComponentsViewModel : ViewModelBase
     private ComponentItemViewModel? _selectedComponentItem;
     private ObservableCollection<ComponentBase> _myComponents = null!;
     private ObservableCollection<ComponentItemViewModel> _myComponentItems = null!;
-    private H.Core.Models.Farm? _selectedFarm;
 
     private IComponentInitializationService? _componentInitializationService;
 
@@ -61,6 +60,12 @@ public class MyComponentsViewModel : ViewModelBase
         
         base.EventAggregator?.GetEvent<ComponentAddedEvent>().Subscribe(OnComponentAddedEvent);
         base.EventAggregator?.GetEvent<EditingComponentsCompletedEvent>().Subscribe(OnEditingComponentsCompletedEvent);
+        
+        // Subscribe to active farm changes
+        if (base.StorageService?.Storage?.ApplicationData?.GlobalSettings != null)
+        {
+            base.StorageService.Storage.ApplicationData.GlobalSettings.PropertyChanged += OnActiveFarmChanged;
+        }
     }
 
     #endregion
@@ -105,11 +110,6 @@ public class MyComponentsViewModel : ViewModelBase
         get => _myComponentItems;
         set => SetProperty(ref _myComponentItems, value);
     }
-    public H.Core.Models.Farm? SelectedFarm
-    {
-        get => _selectedFarm;
-        set => SetProperty(ref _selectedFarm, value);
-    }
 
     public DelegateCommand RemoveComponent { get; } = null!;
     public DelegateCommand<object> SetSelectedComponentCommand { get; set; } = null!;
@@ -127,7 +127,7 @@ public class MyComponentsViewModel : ViewModelBase
 
     public override void InitializeViewModel()
     {
-        if (!base.IsInitialized && base.ActiveFarm is not null)
+        if (!IsInitialized && base.ActiveFarm is not null)
         {
             MyComponents.Clear();
             MyComponentItems.Clear();
@@ -148,6 +148,17 @@ public class MyComponentsViewModel : ViewModelBase
     #endregion
 
     #region Event Handlers
+
+    /// <summary>
+    /// Handles active farm changes and resets initialization state
+    /// </summary>
+    private void OnActiveFarmChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(GlobalSettings.ActiveFarm))
+        {
+            base.IsInitialized = false;
+        }
+    }
 
     /// <summary>
     /// Sets the selected component when a component card is clicked

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/FarmCreationViews/FarmOpenExistingViewModel.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/FarmCreationViews/FarmOpenExistingViewModel.cs
@@ -11,35 +11,17 @@ using System.Linq;
 
 namespace H.Avalonia.ViewModels.FarmCreationViews
 {
-    public class FarmOpenExistingViewmodel : ViewModelBase
+    public class FarmOpenExistingViewmodel : FarmOpenExistingViewModelBase
     {
         #region Fields
-        private readonly IRegionManager _regionManager = null!;
-        private Farm? _selectedFarm;
-        private string _searchText = string.Empty;
-        private ObservableCollection<Farm> _farms = null!;
 
         #endregion
 
         #region Constructors
-        public FarmOpenExistingViewmodel()
-        {
-            
-        }
-        public FarmOpenExistingViewmodel(IRegionManager regionManager, IStorageService storageService) : base(regionManager, storageService)
-        {
-            _regionManager = regionManager ?? throw new System.ArgumentNullException(nameof(regionManager));
-            NavigateToPreviousPage = new DelegateCommand(OnNavigateToPreviousPage);
-            NavigateToNextPage = new DelegateCommand(OnOpenFarmExecute, NextCanExecute);
-            Farms = new ObservableCollection<Farm>();
-        }
 
         public FarmOpenExistingViewmodel(IRegionManager regionManager, IStorageService storageService, INotificationManagerService notificationManager) : base(regionManager, storageService, notificationManager)
         {
-            _regionManager = regionManager ?? throw new System.ArgumentNullException(nameof(regionManager));
             NavigateToPreviousPage = new DelegateCommand(OnNavigateToPreviousPage);
-            NavigateToNextPage = new DelegateCommand(OnOpenFarmExecute, NextCanExecute);
-            Farms = new ObservableCollection<Farm>();
         }
 
         #endregion
@@ -47,63 +29,10 @@ namespace H.Avalonia.ViewModels.FarmCreationViews
         #region Properties
 
         public DelegateCommand NavigateToPreviousPage { get; } = null!;
-        public DelegateCommand NavigateToNextPage { get; } = null!;
-        public ObservableCollection<Farm> Farms
-        {
-            get => _farms;
-            set
-            {
-                SetProperty(ref _farms, value);
-            }
-        }
-
-        public Farm? SelectedFarm
-        {
-            get => _selectedFarm;
-            set
-            {
-                SetProperty(ref _selectedFarm, value);
-                NavigateToNextPage.RaiseCanExecuteChanged();
-            }
-        }
-
-        public string SearchText
-        {
-            get => _searchText;
-            set
-            {
-                SetProperty(ref _searchText, value);
-                if (base.StorageService == null) return;
-
-                if (string.IsNullOrEmpty(value))
-                {
-                    Farms.Clear();
-                    var farms = base.StorageService.GetAllFarms();
-                    Farms.Add(farms);
-                }
-                else
-                {
-                    Farms.Clear();
-                    var farms = base.StorageService!.GetAllFarms().Where(f => (f.Name?.ToLower().Contains(value.ToLower()) ?? false) || (f.DefaultSoilData?.EcodistrictName?.ToLower().Contains(value.ToLower()) ?? false) || f.Province.ToString().ToLower().Contains(value.ToLower()));
-                    Farms.Add(farms);
-                }
-            }
-        }
 
         #endregion
 
         #region Public Methods
-
-        public override void OnNavigatedTo(NavigationContext navigationContext)
-        {
-            Farms.Clear();
-            if (base.StorageService != null)
-            {
-                var farms = base.StorageService.GetAllFarms();
-                Farms.Add(farms);
-            }
-            base.OnNavigatedTo(navigationContext);
-        }
 
         #endregion
 
@@ -111,40 +40,12 @@ namespace H.Avalonia.ViewModels.FarmCreationViews
 
         private void OnNavigateToPreviousPage()
         {
-            _regionManager.RequestNavigate(UiRegions.ContentRegion, nameof(FarmOptionsView));
-        }
-
-        private void OnOpenFarmExecute()
-        {
-            if (this.SelectedFarm is null) return;
-
-            base.StorageService?.SetActiveFarm(this.SelectedFarm);
-            // Line below ensures that the proper unit strings are used for the MeasurementSystemType of the existing farm being opened
-            base.StorageService?.Storage.ApplicationData.DisplayUnitStrings.SetStrings(this.SelectedFarm.MeasurementSystemType);
-
-            this.ClearActiveView(); // likely solves the bug: System.InvalidOperationException: 'Sequence contains no elements'
-            base.RegionManager?.RequestNavigate(UiRegions.SidebarRegion, nameof(MyComponentsView));
-        }
-
-        private void ClearActiveView()
-        {
-            // Clear content region
-            var contentView = this.RegionManager?.Regions[UiRegions.ContentRegion].ActiveViews.SingleOrDefault();
-            if (contentView != null)
-            {
-                this.RegionManager?.Regions[UiRegions.ContentRegion].Deactivate(contentView);
-                this.RegionManager?.Regions[UiRegions.ContentRegion].Remove(contentView);
-            }
+            RegionManager.RequestNavigate(UiRegions.ContentRegion, nameof(FarmOptionsView));
         }
 
         #endregion
 
         #region Event Handler
-
-        private bool NextCanExecute()
-        {
-            return this.SelectedFarm is not null;
-        }
 
         #endregion
     }

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/FarmCreationViews/FarmOpenExistingViewModel.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/FarmCreationViews/FarmOpenExistingViewModel.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace H.Avalonia.ViewModels.FarmCreationViews
 {
-    public class FarmOpenExistingViewmodel : FarmOpenExistingViewModelBase
+    public class FarmOpenExistingViewModel : FarmOpenExistingViewModelBase
     {
         #region Fields
 
@@ -19,7 +19,7 @@ namespace H.Avalonia.ViewModels.FarmCreationViews
 
         #region Constructors
 
-        public FarmOpenExistingViewmodel(IRegionManager regionManager, IStorageService storageService, INotificationManagerService notificationManager) : base(regionManager, storageService, notificationManager)
+        public FarmOpenExistingViewModel(IRegionManager regionManager, IStorageService storageService, INotificationManagerService notificationManager) : base(regionManager, storageService, notificationManager)
         {
             NavigateToPreviousPage = new DelegateCommand(OnNavigateToPreviousPage);
         }

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/FileMenuViews/FileExportFarmViewModel.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/FileMenuViews/FileExportFarmViewModel.cs
@@ -17,9 +17,9 @@ namespace H.Avalonia.ViewModels.OptionsViews.FileMenuViews
     /// <summary>
     /// ViewModel responsible for handling farm export functionality. 
     /// Allows users to select farms and export them to JSON format files.
-    /// Inherits from FarmOpenExistingViewmodel to provide base farm management capabilities.
+    /// Inherits from FarmOpenExistingViewModel to provide base farm management capabilities.
     /// </summary>
-    public class FileExportFarmViewModel : FarmOpenExistingViewmodel
+    public class FileExportFarmViewModel : FarmOpenExistingViewModel
     {
         #region Fields
         /// <summary>

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/FileMenuViews/FileOpenFarmViewModel.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/FileMenuViews/FileOpenFarmViewModel.cs
@@ -1,10 +1,11 @@
 ﻿using H.Avalonia.ViewModels.FarmCreationViews;
+using H.Avalonia.Views.FarmCreationViews;
 using H.Core.Services.StorageService;
 using Prism.Regions;
 
 namespace H.Avalonia.ViewModels.OptionsViews.FileMenuViews
 {
-    public class FileOpenFarmViewModel : FarmOpenExistingViewmodel
+    public class FileOpenFarmViewModel : FarmOpenExistingViewModelBase
     {
         #region Constructors
 

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/OptionsViewModel.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/OptionsViewModel.cs
@@ -46,6 +46,7 @@ namespace H.Avalonia.ViewModels.OptionsViews
 
         public override void OnNavigatedTo(NavigationContext navigationContext)
         {
+            SelectedItem = null;
             this.PropertyChanged += OnSelectedOptionChanged;
             EventAggregator?.GetEvent<ValidationErrorOccurredEvent>().Subscribe(LockNavigation);
             EventAggregator?.GetEvent<ValidationPassOccurredEvent>().Subscribe(UnlockNavigation);

--- a/H.GUI.Avalonia/H.Avalonia/Views/FarmCreationViews/FarmOpenExistingView.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/FarmCreationViews/FarmOpenExistingView.axaml
@@ -11,7 +11,7 @@
 			 x:Class="H.Avalonia.Views.FarmCreationViews.FarmOpenExistingView">
 
 	<Design.DataContext>
-		<farmCreationViews:FarmOpenExistingViewmodel />
+		<farmCreationViews:FarmOpenExistingViewModel />
 	</Design.DataContext>
 
 	<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/H.GUI.Avalonia/H.Avalonia/Views/FarmCreationViews/FarmOpenExistingView.axaml.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Views/FarmCreationViews/FarmOpenExistingView.axaml.cs
@@ -10,15 +10,15 @@ public partial class FarmOpenExistingView : UserControl
 
     #region Fields
 
-    private FarmOpenExistingViewmodel? _farmOpenExistingViewmodel;
+    private FarmOpenExistingViewModel? _farmOpenExistingViewmodel;
 
     #endregion
 
     #region Constructors
-    public FarmOpenExistingView(FarmOpenExistingViewmodel farmOpenExistingViewmodel)
+    public FarmOpenExistingView(FarmOpenExistingViewModel farmOpenExistingViewModel)
     {
         InitializeComponent();
-        _farmOpenExistingViewmodel = farmOpenExistingViewmodel ?? throw new ArgumentNullException(nameof(farmOpenExistingViewmodel));
+        _farmOpenExistingViewmodel = farmOpenExistingViewModel ?? throw new ArgumentNullException(nameof(farmOpenExistingViewModel));
     }
     public FarmOpenExistingView()
     {

--- a/H.GUI.Avalonia/H.Avalonia/Views/FarmCreationViews/FarmOpenExistingViewModelBase.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Views/FarmCreationViews/FarmOpenExistingViewModelBase.cs
@@ -1,0 +1,143 @@
+﻿using DynamicData;
+using H.Avalonia.Services;
+using H.Avalonia.ViewModels;
+using H.Avalonia.Views.ComponentViews;
+using H.Core.Models;
+using H.Core.Services.StorageService;
+using Prism.Commands;
+using Prism.Regions;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace H.Avalonia.Views.FarmCreationViews
+{
+    public class FarmOpenExistingViewModelBase : ViewModelBase
+    {
+        #region Fields
+        private readonly IRegionManager _regionManager = null!;
+        private Farm? _selectedFarm;
+        private string _searchText = string.Empty;
+        private ObservableCollection<Farm> _farms = null!;
+        #endregion
+
+        #region Constructors
+
+        public FarmOpenExistingViewModelBase(IRegionManager regionManager, IStorageService storageService) : base(regionManager, storageService)
+        {
+            NavigateToNextPage = new DelegateCommand(OnOpenFarmExecute, NextCanExecute);
+            Farms = new ObservableCollection<Farm>();
+        }
+
+        public FarmOpenExistingViewModelBase(IRegionManager regionManager, IStorageService storageService, INotificationManagerService notificationManager) : base(regionManager, storageService, notificationManager)
+        {
+            NavigateToNextPage = new DelegateCommand(OnOpenFarmExecute, NextCanExecute);
+            Farms = new ObservableCollection<Farm>();
+        }
+
+        #endregion
+
+        #region Properties
+        public DelegateCommand NavigateToNextPage { get; } = null!;
+
+        public Farm? SelectedFarm
+        {
+            get => _selectedFarm;
+            set
+            {
+                SetProperty(ref _selectedFarm, value);
+                NavigateToNextPage.RaiseCanExecuteChanged();
+            }
+        }
+
+        public ObservableCollection<Farm> Farms
+        {
+            get => _farms;
+            set
+            {
+                SetProperty(ref _farms, value);
+            }
+        }
+
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                SetProperty(ref _searchText, value);
+                if (base.StorageService == null) return;
+
+                if (string.IsNullOrEmpty(value))
+                {
+                    Farms.Clear();
+                    var farms = base.StorageService.GetAllFarms();
+                    Farms.Add(farms);
+                }
+                else
+                {
+                    Farms.Clear();
+                    var farms = base.StorageService!.GetAllFarms().Where(f => (f.Name?.ToLower().Contains(value.ToLower()) ?? false) || (f.DefaultSoilData?.EcodistrictName?.ToLower().Contains(value.ToLower()) ?? false) || f.Province.ToString().ToLower().Contains(value.ToLower()));
+                    Farms.Add(farms);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public override void OnNavigatedTo(NavigationContext navigationContext)
+        {
+            Farms.Clear();
+            if (base.StorageService != null)
+            {
+                var farms = base.StorageService.GetAllFarms();
+                Farms.Add(farms);
+            }
+            base.OnNavigatedTo(navigationContext);
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private void OnOpenFarmExecute()
+        {
+            if (this.SelectedFarm is null) return;
+
+            base.StorageService?.SetActiveFarm(this.SelectedFarm);
+            // Line below ensures that the proper unit strings are used for the MeasurementSystemType of the existing farm being opened
+
+            base.StorageService?.Storage.ApplicationData.DisplayUnitStrings.SetStrings(this.SelectedFarm.MeasurementSystemType);
+
+            this.ClearActiveView(); // likely solves the bug: System.InvalidOperationException: 'Sequence contains no elements'
+            base.RegionManager?.RequestNavigate(UiRegions.SidebarRegion, nameof(MyComponentsView));
+        }
+
+        private void ClearActiveView()
+        {
+            // Clear content region
+            var contentView = this.RegionManager?.Regions[UiRegions.ContentRegion].ActiveViews.SingleOrDefault();
+            if (contentView != null)
+            {
+                this.RegionManager?.Regions[UiRegions.ContentRegion].Deactivate(contentView);
+                this.RegionManager?.Regions[UiRegions.ContentRegion].Remove(contentView);
+            }
+        }
+
+        #endregion
+
+        #region Event Handlers
+
+        private bool NextCanExecute()
+        {
+            return this.SelectedFarm is not null;
+        }
+
+        #endregion
+
+    }
+}


### PR DESCRIPTION
# Changes made
### MyComponentsViewModel
- Made fix for situation when user loads a farm file initially, navigates to the settings and attempts to load a different farm file. Screen would return to the component selection sidebar view and component view in the content region, though content of original farm would still be shown. Fix implemented now correctly loads the selected view and shows the correct components in the sidebar view.
### OptionsViewModel
- When user loads the options view sidebar and selects an option, the content region gets filled. If the user returns back to component view and back to settings, an option remains selected but the content region empty. Set so the option tab selected is null on navigated to in order to avoid this.
### FarmOpenExistingViewModelBase
- Factored out shared functionality to base class from FarmOpenExistingViewModel to be used in FarmOpenExistingViewmodel and FileOpenFarmViewModel
- Corrected capitalization in FarmOpenExistingViewModel from FarmOpenExistingViewmodel