### PR TITLE
Addition of missing Energy and Crop Default placeholder tabs in options menu

### DIFF
--- a/H.GUI.Avalonia/H.Avalonia/Infrastructure/DependencyInjection/ContainerRegistrationService.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Infrastructure/DependencyInjection/ContainerRegistrationService.cs
@@ -232,6 +232,8 @@ namespace H.Avalonia.Infrastructure.DependencyInjection
             containerRegistry.RegisterForNavigation<FarmImportFileView, FarmImportFileViewModel>();
             containerRegistry.RegisterForNavigation<FileExportClimateView, FileExportClimateViewModel>();
             containerRegistry.RegisterForNavigation<FileExportManureView, FileExportManureViewModel>();
+            containerRegistry.RegisterForNavigation<EnergySettingsView, EnergySettingsViewModel>();
+            containerRegistry.RegisterForNavigation<CropDefaultsSettingsView, CropDefaultsSettingsViewModel>();
             
             _logger.LogDebug("Completed registration of options and settings views");
         }

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/CropDefaultsSettingsViewModel.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/CropDefaultsSettingsViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace H.Avalonia.ViewModels.OptionsViews
+{
+    public class CropDefaultsSettingsViewModel
+    {
+    }
+}

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/EnergySettingsViewModel.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/EnergySettingsViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace H.Avalonia.ViewModels.OptionsViews
+{
+    public class EnergySettingsViewModel
+    {
+    }
+}

--- a/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/OptionsViewModel.cs
+++ b/H.GUI.Avalonia/H.Avalonia/ViewModels/OptionsViews/OptionsViewModel.cs
@@ -144,6 +144,12 @@ namespace H.Avalonia.ViewModels.OptionsViews
                     case "User Settings":
                         base.RegionManager?.RequestNavigate(UiRegions.ContentRegion, nameof(Views.OptionsViews.OptionUserSettingsView));
                         break;
+                    case "Energy":
+                        base.RegionManager?.RequestNavigate(UiRegions.ContentRegion, nameof(Views.OptionsViews.EnergySettingsView));
+                        break;
+                    case "Crop Defaults":
+                        base.RegionManager?.RequestNavigate(UiRegions.ContentRegion, nameof(Views.OptionsViews.CropDefaultsSettingsView));
+                        break;
                 }
             }
         }

--- a/H.GUI.Avalonia/H.Avalonia/Views/OptionsViews/CropDefaultsSettingsView.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/OptionsViews/CropDefaultsSettingsView.axaml
@@ -1,0 +1,8 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="H.Avalonia.Views.OptionsViews.CropDefaultsSettingsView">
+  This is the crop defaults settings view.
+</UserControl>

--- a/H.GUI.Avalonia/H.Avalonia/Views/OptionsViews/CropDefaultsSettingsView.axaml.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Views/OptionsViews/CropDefaultsSettingsView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace H.Avalonia.Views.OptionsViews;
+
+public partial class CropDefaultsSettingsView : UserControl
+{
+    public CropDefaultsSettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/H.GUI.Avalonia/H.Avalonia/Views/OptionsViews/EnergySettingsView.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/OptionsViews/EnergySettingsView.axaml
@@ -1,0 +1,8 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="H.Avalonia.Views.OptionsViews.EnergySettingsView">
+  This is the energy settings view.
+</UserControl>

--- a/H.GUI.Avalonia/H.Avalonia/Views/OptionsViews/EnergySettingsView.axaml.cs
+++ b/H.GUI.Avalonia/H.Avalonia/Views/OptionsViews/EnergySettingsView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace H.Avalonia.Views.OptionsViews;
+
+public partial class EnergySettingsView : UserControl
+{
+    public EnergySettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/H.GUI.Avalonia/H.Avalonia/Views/OptionsViews/OptionsView.axaml
+++ b/H.GUI.Avalonia/H.Avalonia/Views/OptionsViews/OptionsView.axaml
@@ -57,6 +57,8 @@
 					<ListBoxItem Content="{Binding [Label_Farm].Value, Source={StaticResource Loc}}"/>
 					<ListBoxItem Content="{Binding [Label_Soil].Value, Source={StaticResource Loc}}"/>
 					<ListBoxItem Content="{Binding [Label_UserSettings].Value, Source={StaticResource Loc}}"/>
+                    <ListBoxItem Content="{Binding [Label_Energy].Value, Source={StaticResource Loc}}"/>
+                    <ListBoxItem Content="{Binding [Label_CropDefaults].Value, Source={StaticResource Loc}}"/>
 
 					<!-- Climate & Weather -->
 					<ListBoxItem Margin="-5, 10, 0, 0" IsEnabled="False" >

--- a/H.Localization/Resources/Strings/AppStrings.Designer.cs
+++ b/H.Localization/Resources/Strings/AppStrings.Designer.cs
@@ -3712,6 +3712,15 @@ namespace H.Localization.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Crop Defaults.
+        /// </summary>
+        public static string Label_CropDefaults {
+            get {
+                return ResourceManager.GetString("Label_CropDefaults", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Crop Details.
         /// </summary>
         public static string Label_CropDetails {
@@ -4185,6 +4194,15 @@ namespace H.Localization.Resources.Strings {
         public static string Label_EndYear {
             get {
                 return ResourceManager.GetString("Label_EndYear", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Energy.
+        /// </summary>
+        public static string Label_Energy {
+            get {
+                return ResourceManager.GetString("Label_Energy", resourceCulture);
             }
         }
         

--- a/H.Localization/Resources/Strings/AppStrings.fr.resx
+++ b/H.Localization/Resources/Strings/AppStrings.fr.resx
@@ -3350,4 +3350,10 @@ Hassan Afzaal</value>
   <data name="Label_MultiYearCarbonModelling" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="Label_Energy" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="Label_CropDefaults" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
 </root>

--- a/H.Localization/Resources/Strings/AppStrings.resx
+++ b/H.Localization/Resources/Strings/AppStrings.resx
@@ -4302,4 +4302,10 @@ Hassan Afzaal</value>
   <data name="Label_MultiYearCarbonModelling" xml:space="preserve">
     <value>Multiyear Carbon Modelling</value>
   </data>
+  <data name="Label_Energy" xml:space="preserve">
+    <value>Energy</value>
+  </data>
+  <data name="Label_CropDefaults" xml:space="preserve">
+    <value>Crop Defaults</value>
+  </data>
 </root>


### PR DESCRIPTION
Added tabs missing from V4. Added these for screenshot purposes used in the [V5 user guide](https://github.com/holos-aafc/Holos-5/tree/V5-User-Guide) to populate the options with tabs that exist in V4 guide but aren't yet functional in V5.